### PR TITLE
Fix await identifier bug

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -45,6 +45,7 @@ parking_lot = "0.12"
 rustc-hash = "1.1"
 ahash = "0.8"
 crossbeam = "0.8"
+libc = "0.2"
 
 # Memory management
 bumpalo = "3.13"

--- a/rust/fluentai-core/Cargo.toml
+++ b/rust/fluentai-core/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot.workspace = true
 bumpalo.workspace = true
 tracing.workspace = true
 crossbeam.workspace = true
+libc.workspace = true
 num_cpus = "1.16"
 
 [dev-dependencies]

--- a/rust/fluentai-vm/src/simd.rs
+++ b/rust/fluentai-vm/src/simd.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{anyhow, Result};
 use fluentai_core::value::Value;
+use std::mem;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use std::arch::x86_64::*;
 

--- a/rust/fluentai-vm/src/vm.rs
+++ b/rust/fluentai-vm/src/vm.rs
@@ -1682,7 +1682,7 @@ impl VM {
                     }
                 } else {
                     return Err(VMError::UnknownIdentifier {
-                        name: format!("promise:{}", promise_id),
+                        name: promise_id.to_string(),
                         location: None,
                         stack_trace: None,
                     });


### PR DESCRIPTION
This PR fixes the await identifier bug described in issue #9.

## Changes
- Fixed double prefixing issue in VM's await error handling
- Changed `format!("promise:{}", promise_id)` to `promise_id.to_string()`
- Added missing libc dependency to fix compilation errors
- Added missing std::mem import to fix SIMD compilation

## Issue
The original issue: await operation incorrectly tried to resolve "promise:promise:1" instead of "promise:1" due to double prefixing in error message formatting.

Fixes #9

## Testing
- All VM module tests (130) are passing
- Most workspace tests are passing
- 3 pre-existing effect integration test failures are unrelated to this fix


Generated with [Claude Code](https://claude.ai/code)