### PR TITLE
feat: Implement basic async/await runtime execution

### DIFF
--- a/rust/fluentai-mcp/src/handlers.rs
+++ b/rust/fluentai-mcp/src/handlers.rs
@@ -258,6 +258,7 @@ fn format_value(value: &Value) -> String {
         }
         Value::Function { .. } => "<function>".to_string(),
         Value::Promise(id) => format!("<promise:{}>", id),
+        Value::Future { .. } => "<future>".to_string(),
         Value::Channel(id) => format!("<channel:{}>", id),
         Value::Cell(idx) => format!("<cell:{}>", idx),
         Value::Tagged { tag, values } => {

--- a/rust/fluentai-py/src/lib.rs
+++ b/rust/fluentai-py/src/lib.rs
@@ -461,6 +461,7 @@ fn value_to_python(py: Python, value: &Value) -> PyResult<PyObject> {
             Ok(py_dict.to_object(py))
         }
         Value::Promise(id) => Ok(format!("<promise:{}>", id).to_object(py)),
+        Value::Future { chunk_id, .. } => Ok(format!("<future:{}>", chunk_id).to_object(py)),
         Value::Channel(id) => Ok(format!("<channel:{}>", id).to_object(py)),
         Value::Cell(id) => Ok(format!("<cell:{}>", id).to_object(py)),
         Value::Tagged { tag, values } => {

--- a/rust/fluentai-viz/src/debug.rs
+++ b/rust/fluentai-viz/src/debug.rs
@@ -151,6 +151,7 @@ pub fn serialize_value(value: &Value) -> String {
             format!("{{{}{}}}", items.join(", "), suffix)
         }
         Value::Promise(id) => format!("<promise:{}>", id),
+        Value::Future { .. } => "<future>".to_string(),
         Value::Channel(id) => format!("<channel:{}>", id),
         Value::GcHandle(_) => "<gc-handle>".to_string(),
         Value::Symbol(s) => format!(":{}", s),

--- a/rust/fluentai-vm/src/bytecode.rs
+++ b/rust/fluentai-vm/src/bytecode.rs
@@ -74,6 +74,7 @@ pub enum Opcode {
     MakeFunc,
     MakeClosure,  // Like MakeFunc but captures N values from stack
     LoadCaptured, // Load value from captured environment
+    MakeFuture,   // Create a future from a function
     MakeEnv,
     PopEnv,
 

--- a/rust/fluentai-vm/src/concurrent_gc.rs
+++ b/rust/fluentai-vm/src/concurrent_gc.rs
@@ -468,6 +468,11 @@ impl ConcurrentGc {
                     self.scan_value(v);
                 }
             }
+            Value::Future { env, .. } => {
+                for v in env {
+                    self.scan_value(v);
+                }
+            }
             Value::Tagged { values, .. } => {
                 for v in values {
                     self.scan_value(v);
@@ -518,6 +523,11 @@ impl ConcurrentGc {
                 }
             }
             Value::Function { env, .. } => {
+                for v in env {
+                    self.scan_value_concurrent(v, gray_queue, guard);
+                }
+            }
+            Value::Future { env, .. } => {
                 for v in env {
                     self.scan_value_concurrent(v, gray_queue, guard);
                 }
@@ -689,6 +699,7 @@ impl ConcurrentGc {
             Value::NativeFunction { .. } => 64, // Arc + fields
             Value::Function { env, .. } => 32 + env.len() * 8,
             Value::Promise(_) => 16,
+            Value::Future { env, .. } => 32 + env.len() * 8,
             Value::Channel(_) => 16,
             Value::Cell(_) => 16,
             Value::Tagged { values, .. } => 32 + values.len() * 8,

--- a/rust/fluentai-vm/src/error.rs
+++ b/rust/fluentai-vm/src/error.rs
@@ -401,6 +401,7 @@ pub fn value_type_name(value: &Value) -> &'static str {
         Value::NativeFunction { .. } => "native-function",
         Value::Function { .. } => "function",
         Value::Promise(_) => "promise",
+        Value::Future { .. } => "future",
         Value::Channel(_) => "channel",
         Value::Cell(_) => "cell",
         Value::Tagged { .. } => "tagged",

--- a/rust/fluentai-vm/tests/async_comprehensive_test.rs
+++ b/rust/fluentai-vm/tests/async_comprehensive_test.rs
@@ -89,7 +89,6 @@ fn test_spawn_with_channel() {
 }
 
 #[test]
-#[ignore = "Async/await not fully implemented yet"]
 fn test_async_await_simple() {
     // Test basic async/await
     let result = compile_and_run(


### PR DESCRIPTION
## Summary
- Implemented basic async/await runtime execution for FluentAI
- Added Future type to represent unevaluated async computations
- Fixed await operation to handle both Futures and Promises

## Changes
1. **Added Future variant to Value enum**
   - Future contains chunk_id and captured environment
   - Updated all pattern matching across the codebase

2. **Updated async compilation**
   - async expressions now create Futures instead of immediately spawning
   - Added MakeFuture opcode to convert functions to futures

3. **Implemented await operation**
   - Await spawns future execution in a separate VM instance
   - Uses channels to communicate results back to main execution
   - Works for both Future and Promise values

4. **Fixed test_async_await_simple**
   - Basic async/await now works correctly
   - Test moved from ignored to active

## Test Results
```
test test_async_await_simple ... ok
test result: ok. 8 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```

## Known Limitations
This is a basic implementation that blocks execution during await. A full implementation would need:
- Proper suspension/resumption mechanics
- Async runtime integration without blocking
- Support for concurrent await operations

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)