### PR TITLE
feat: Add resource limits for error handler stack

### DIFF
--- a/rust/fluentai-vm/src/safety.rs
+++ b/rust/fluentai-vm/src/safety.rs
@@ -166,6 +166,7 @@ pub struct ResourceLimits {
     pub max_channels: usize,
     pub max_memory_bytes: usize,
     pub channel_buffer_size: usize,
+    pub max_error_handlers: usize,
 }
 
 impl Default for ResourceLimits {
@@ -178,6 +179,7 @@ impl Default for ResourceLimits {
             max_channels: 1_000,
             max_memory_bytes: 100 * 1024 * 1024, // 100MB
             channel_buffer_size: 1024,
+            max_error_handlers: 1_000,
         }
     }
 }
@@ -193,6 +195,7 @@ impl ResourceLimits {
             max_channels: 10,
             max_memory_bytes: 10 * 1024 * 1024, // 10MB
             channel_buffer_size: 100,
+            max_error_handlers: 100,
         }
     }
 
@@ -206,6 +209,7 @@ impl ResourceLimits {
             max_channels: 5,
             max_memory_bytes: 1024 * 1024, // 1MB
             channel_buffer_size: 10,
+            max_error_handlers: 20,
         }
     }
 }

--- a/rust/fluentai-vm/src/vm.rs
+++ b/rust/fluentai-vm/src/vm.rs
@@ -3207,6 +3207,17 @@ impl VM {
                         // Push handler back for catch execution after finally
                         let mut catch_handler = handler.clone();
                         catch_handler.finally_ip = None; // Prevent infinite loop
+                        
+                        // Check resource limit
+                        if self.error_handler_stack.len() >= self.resource_limits.max_error_handlers {
+                            return Err(VMError::ResourceLimitExceeded {
+                                resource: "error handlers".to_string(),
+                                limit: self.resource_limits.max_error_handlers,
+                                requested: self.error_handler_stack.len() + 1,
+                                stack_trace: None,
+                            });
+                        }
+                        
                         self.error_handler_stack.push(catch_handler);
                         
                         return Ok(VMState::Continue);
@@ -3256,6 +3267,16 @@ impl VM {
                     });
                 }
                 
+                // Check resource limit
+                if self.error_handler_stack.len() >= self.resource_limits.max_error_handlers {
+                    return Err(VMError::ResourceLimitExceeded {
+                        resource: "error handlers".to_string(),
+                        limit: self.resource_limits.max_error_handlers,
+                        requested: self.error_handler_stack.len() + 1,
+                        stack_trace: None,
+                    });
+                }
+                
                 self.error_handler_stack.push(ErrorHandler {
                     catch_ip,
                     finally_ip: None, // Will be set by PushFinally if present
@@ -3269,7 +3290,11 @@ impl VM {
                 let finally_ip = instruction.arg as usize;
                 
                 // Validate that finally_ip is within bounds
-                let current_frame = self.get_current_frame()?;
+                let current_frame = self.call_stack.last()
+                    .ok_or_else(|| VMError::RuntimeError {
+                        message: "No active call frame for finally handler".to_string(),
+                        stack_trace: None,
+                    })?;
                 let chunk = &self.bytecode.chunks[current_frame.chunk_id];
                 if finally_ip >= chunk.instructions.len() {
                     return Err(VMError::RuntimeError {

--- a/rust/fluentai-vm/src/vm_simple_coverage_tests.rs
+++ b/rust/fluentai-vm/src/vm_simple_coverage_tests.rs
@@ -305,6 +305,7 @@ mod tests {
             max_channels: 10,
             max_memory_bytes: 1024 * 1024,
             channel_buffer_size: 256,
+            max_error_handlers: 100,
         };
 
         vm.set_resource_limits(limits);

--- a/rust/fluentai-vm/tests/error_handler_limits_test.rs
+++ b/rust/fluentai-vm/tests/error_handler_limits_test.rs
@@ -1,0 +1,273 @@
+//! Tests for error handler stack resource limits
+
+use anyhow::Result;
+use fluentai_core::value::Value;
+use fluentai_vm::{compiler::{Compiler, CompilerOptions}, VM};
+use std::sync::Arc;
+use fluentai_effects::EffectRuntime;
+use fluentai_optimizer::OptimizationLevel;
+use fluentai_vm::safety::ResourceLimits;
+use fluentai_vm::error::VMError;
+
+fn run_with_limits(source: &str, limits: ResourceLimits) -> Result<Value> {
+    // Parse the source code
+    let graph = fluentai_parser::parse(source)
+        .map_err(|e| anyhow::anyhow!("Parse error: {:?}", e))?;
+
+    // Compile to bytecode without optimization
+    let options = CompilerOptions {
+        optimization_level: OptimizationLevel::None,
+        debug_info: true,
+    };
+    let compiler = Compiler::with_options(options);
+    let bytecode = compiler.compile(&graph)?;
+
+    // Create VM with effect runtime and custom limits
+    let runtime = Arc::new(EffectRuntime::new()?);
+    let mut vm = VM::new(bytecode);
+    vm.set_resource_limits(limits);
+    vm.set_effect_runtime(runtime);
+
+    // Run the VM
+    Ok(vm.run()?)
+}
+
+#[test]
+fn test_deeply_nested_try_catch_hits_limit() {
+    // Create very low limits for testing
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 3;
+    
+    // Create deeply nested try-catch blocks
+    let code = r#"
+        (try 
+            (try
+                (try
+                    (try
+                        42
+                        (catch e1 e1))
+                    (catch e2 e2))
+                (catch e3 e3))
+            (catch e4 e4))
+    "#;
+    
+    let result = run_with_limits(code, limits);
+    match result {
+        Err(e) => {
+            // Check that we get the right error type
+            if let Some(vm_error) = e.downcast_ref::<VMError>() {
+                match vm_error {
+                    VMError::ResourceLimitExceeded { resource, limit, requested, .. } => {
+                        assert_eq!(resource, "error handlers");
+                        assert_eq!(*limit, 3);
+                        assert_eq!(*requested, 4);
+                    }
+                    _ => panic!("Expected ResourceLimitExceeded, got {:?}", vm_error),
+                }
+            } else {
+                panic!("Expected VMError, got {:?}", e);
+            }
+        }
+        Ok(_) => panic!("Expected error due to limit, but succeeded"),
+    }
+}
+
+#[test]
+fn test_deeply_nested_try_finally_hits_limit() {
+    // Create very low limits for testing
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 3;
+    
+    // Create deeply nested try-finally blocks
+    let code = r#"
+        (try 
+            (try
+                (try
+                    (try
+                        42
+                        (finally 1))
+                    (finally 2))
+                (finally 3))
+            (finally 4))
+    "#;
+    
+    let result = run_with_limits(code, limits);
+    match result {
+        Err(e) => {
+            // Check that we get the right error type
+            if let Some(vm_error) = e.downcast_ref::<VMError>() {
+                match vm_error {
+                    VMError::ResourceLimitExceeded { resource, limit, requested, .. } => {
+                        assert_eq!(resource, "error handlers");
+                        assert_eq!(*limit, 3);
+                        assert_eq!(*requested, 4);
+                    }
+                    _ => panic!("Expected ResourceLimitExceeded, got {:?}", vm_error),
+                }
+            } else {
+                panic!("Expected VMError, got {:?}", e);
+            }
+        }
+        Ok(_) => panic!("Expected error due to limit, but succeeded"),
+    }
+}
+
+#[test]
+fn test_recursive_function_with_try_catch() {
+    // Create low limits for testing
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 5;
+    limits.max_call_depth = 10; // Also limit call depth
+    
+    // Create recursive function with try-catch
+    let code = r#"
+        (define (recurse n)
+            (try
+                (if (= n 0)
+                    42
+                    (recurse (- n 1)))
+                (catch e e)))
+        (recurse 10)
+    "#;
+    
+    let result = run_with_limits(code, limits);
+    match result {
+        Err(e) => {
+            // Could hit either error handler limit or call depth limit
+            if let Some(vm_error) = e.downcast_ref::<VMError>() {
+                match vm_error {
+                    VMError::ResourceLimitExceeded { resource, .. } => {
+                        assert_eq!(resource, "error handlers");
+                    }
+                    VMError::CallStackOverflow { .. } => {
+                        // This is also acceptable - depends on which limit hits first
+                    }
+                    _ => panic!("Expected ResourceLimitExceeded or CallStackOverflow, got {:?}", vm_error),
+                }
+            } else {
+                panic!("Expected VMError, got {:?}", e);
+            }
+        }
+        Ok(_) => panic!("Expected error due to limit, but succeeded"),
+    }
+}
+
+#[test]
+fn test_exactly_at_limit_works() {
+    // Create limits that allow exactly 3 handlers
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 3;
+    
+    // Create exactly 3 nested try-catch blocks
+    let code = r#"
+        (try 
+            (try
+                (try
+                    42
+                    (catch e1 e1))
+                (catch e2 e2))
+            (catch e3 e3))
+    "#;
+    
+    let result = run_with_limits(code, limits).unwrap();
+    assert_eq!(result, Value::Integer(42));
+}
+
+#[test]
+fn test_sandboxed_limits() {
+    // Use sandboxed limits (100 error handlers)
+    let limits = ResourceLimits::sandboxed();
+    
+    // Create a reasonable amount of nesting that should work
+    let mut code = String::from("(try ");
+    for _ in 0..50 {
+        code.push_str("(try ");
+    }
+    code.push_str("42");
+    for i in 0..50 {
+        code.push_str(&format!(" (catch e{} e{}))", i, i));
+    }
+    code.push_str(" (catch e_outer e_outer))");
+    
+    let result = run_with_limits(&code, limits).unwrap();
+    assert_eq!(result, Value::Integer(42));
+}
+
+#[test]
+fn test_mixed_try_catch_finally() {
+    // Create low limits for testing
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 4;
+    
+    // Create mixed try-catch-finally blocks
+    let code = r#"
+        (try 
+            (try
+                (try
+                    (try
+                        (try
+                            42
+                            (catch e1 e1))
+                        (finally 1))
+                    (catch e2 e2))
+                (finally 2))
+            (catch e3 e3))
+    "#;
+    
+    let result = run_with_limits(code, limits);
+    match result {
+        Err(e) => {
+            // Check that we get the right error type
+            if let Some(vm_error) = e.downcast_ref::<VMError>() {
+                match vm_error {
+                    VMError::ResourceLimitExceeded { resource, limit, requested, .. } => {
+                        assert_eq!(resource, "error handlers");
+                        assert_eq!(*limit, 4);
+                        assert_eq!(*requested, 5);
+                    }
+                    _ => panic!("Expected ResourceLimitExceeded, got {:?}", vm_error),
+                }
+            } else {
+                panic!("Expected VMError, got {:?}", e);
+            }
+        }
+        Ok(_) => panic!("Expected error due to limit, but succeeded"),
+    }
+}
+
+#[test]
+fn test_error_handler_limit_prevents_attack() {
+    // Create low limits for testing - simulating a malicious script
+    let mut limits = ResourceLimits::testing();
+    limits.max_error_handlers = 10;
+    
+    // Create a malicious script that tries to exhaust error handlers
+    let mut code = String::from("(try ");
+    for _ in 0..20 {
+        code.push_str("(try ");
+    }
+    code.push_str("(throw \"error\")");
+    for i in 0..20 {
+        code.push_str(&format!(" (catch e{} e{}))", i, i));
+    }
+    code.push_str(" (catch e_outer e_outer))");
+    
+    let result = run_with_limits(&code, limits);
+    match result {
+        Err(e) => {
+            // We expect to hit the limit during compilation/execution
+            if let Some(vm_error) = e.downcast_ref::<VMError>() {
+                match vm_error {
+                    VMError::ResourceLimitExceeded { resource, limit, .. } => {
+                        assert_eq!(resource, "error handlers");
+                        assert_eq!(*limit, 10);
+                    }
+                    _ => panic!("Expected ResourceLimitExceeded, got {:?}", vm_error),
+                }
+            } else {
+                panic!("Expected VMError, got {:?}", e);
+            }
+        }
+        Ok(_) => panic!("Expected error due to limit, but succeeded"),
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable resource limits for error handler stack to prevent DoS attacks
- Default limits: 1000 for normal use, 100 for sandboxed, 20 for testing
- Add bounds checking in PushHandler and Throw opcodes

## Changes
1. **Updated ResourceLimits struct** in `safety.rs`:
   - Added `max_error_handlers` field
   - Set appropriate defaults for different use cases

2. **Added limit checking** in `vm.rs`:
   - Check before pushing error handlers in PushHandler opcode
   - Check before re-pushing handlers in Throw opcode (for finally execution)
   - Return `ResourceLimitExceeded` error when limit is hit

3. **Created comprehensive tests** in `error_handler_limits_test.rs`:
   - Test deeply nested try-catch blocks
   - Test deeply nested try-finally blocks
   - Test recursive functions with error handlers
   - Test exact limit boundary
   - Test sandboxed limits
   - Test mixed try-catch-finally scenarios
   - Test malicious attack prevention

## Test Results
All new tests pass:
```
running 7 tests
test test_error_handler_limit_prevents_attack ... ok
test test_deeply_nested_try_catch_hits_limit ... ok
test test_sandboxed_limits ... ok
test test_recursive_function_with_try_catch ... ok
test test_mixed_try_catch_finally ... ok
test test_deeply_nested_try_finally_hits_limit ... ok
test test_exactly_at_limit_works ... ok

test result: ok. 7 passed; 0 failed
```

All VM lib tests pass (340 tests).

## Notes
- This addresses issue #54
- Pre-existing test failures in finally_tests.rs are unrelated to these changes
- The implementation follows existing patterns for resource limits in the VM

🤖 Generated with [Claude Code](https://claude.ai/code)