### PR TITLE
feat: Complete FLC actor syntax implementation

### DIFF
--- a/rust/fluentai-parser/tests/actor_field_access_tests.rs
+++ b/rust/fluentai-parser/tests/actor_field_access_tests.rs
@@ -121,7 +121,7 @@ fn test_no_transformation_outside_handler() {
     "#;
     
     let result = parse(source);
-    assert!(result.is_ok(), "Failed to parse actor with mixed contexts");
+    assert!(result.is_ok(), "Failed to parse actor with mixed contexts: {:?}", result);
 }
 
 #[test]

--- a/rust/fluentai-parser/tests/test_actor_comprehensive.rs
+++ b/rust/fluentai-parser/tests/test_actor_comprehensive.rs
@@ -1,0 +1,174 @@
+use fluentai_parser::parse_flc;
+use fluentai_core::ast::Node;
+
+#[test]
+fn test_actor_with_all_features() {
+    let source = r#"
+        private actor BankAccount {
+            balance: float = 0.0;
+            overdraft_limit: float = 100.0;
+            status: string = "active";
+            
+            // Multiple typed handlers
+            private handle deposit(amount: float) {
+                if (amount > 0.0) {
+                    f"Deposited ${amount}. New balance: ${balance + amount}"
+                } else {
+                    "Invalid deposit amount"
+                }
+            }
+            
+            private handle withdraw(amount: float) {
+                let new_balance = balance - amount;
+                if (new_balance >= -overdraft_limit) {
+                    f"Withdrew ${amount}. New balance: ${new_balance}"
+                } else {
+                    "Insufficient funds"
+                }
+            }
+            
+            private handle get_balance() {
+                f"Current balance: ${balance}"
+            }
+            
+            private handle freeze() {
+                "Account frozen"
+            }
+            
+            // Handler with receive and timeout
+            private handle process_transaction(tx) {
+                receive {
+                    "deposit" => "Processing deposit",
+                    "withdraw" => "Processing withdraw",
+                    "query" => get_balance()
+                } after(30000) {
+                    "Transaction timeout"
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse comprehensive actor: {:?}", result);
+    
+    let graph = result.unwrap();
+    
+    // Verify multiple handlers were created
+    let handlers: Vec<_> = graph.nodes.values().filter_map(|node| {
+        match node {
+            Node::Define { name, .. } if name.starts_with("handle_") => Some(name.clone()),
+            _ => None
+        }
+    }).collect();
+    
+    assert!(handlers.len() >= 5, "Expected at least 5 handlers, found {}", handlers.len());
+    assert!(handlers.contains(&"handle_deposit".to_string()));
+    assert!(handlers.contains(&"handle_withdraw".to_string()));
+    assert!(handlers.contains(&"handle_get_balance".to_string()));
+    assert!(handlers.contains(&"handle_freeze".to_string()));
+    assert!(handlers.contains(&"handle_process_transaction".to_string()));
+    
+    // Verify field access transformation occurred
+    let has_balance_getter = graph.nodes.values().any(|node| {
+        if let Node::Variable { name } = node {
+            name == "get_balance" || name == "get_overdraft_limit" || name == "get_status"
+        } else {
+            false
+        }
+    });
+    assert!(has_balance_getter, "Field access should be transformed to getters");
+    
+    
+    // Verify receive with timeout exists
+    let has_receive_timeout = graph.nodes.values().any(|node| {
+        matches!(node, Node::ActorReceive { timeout: Some(_), .. })
+    });
+    assert!(has_receive_timeout, "Should have receive with timeout");
+}
+
+
+#[test] 
+fn test_actor_state_machine() {
+    let source = r#"
+        private actor TrafficLight {
+            color: string = "red";
+            timer: int = 0;
+            
+            private handle tick() {
+                match color {
+                    "red" => {
+                        if (timer >= 30) {
+                            "Changed to green"
+                        } else {
+                            f"Red for {timer + 1} seconds"
+                        }
+                    },
+                    "green" => {
+                        if (timer >= 25) {
+                            "Changed to yellow"
+                        } else {
+                            f"Green for {timer + 1} seconds"
+                        }
+                    },
+                    "yellow" => {
+                        if (timer >= 5) {
+                            "Changed to red"
+                        } else {
+                            f"Yellow for {timer + 1} seconds"
+                        }
+                    }
+                }
+            }
+            
+            private handle get_status() {
+                f"Light is {color}, timer at {timer}"
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse state machine actor: {:?}", result);
+}
+
+#[test]
+fn test_actor_with_private_helpers() {
+    let source = r#"
+        private actor OrderProcessor {
+            orders: List<Map<string, any>> = [];
+            total_revenue: float = 0.0;
+            
+            // Private helper function
+            private function validate_order(order: Map<string, any>) {
+                order.get("amount").is_some() && 
+                order.get("item").is_some() &&
+                order.get("amount").unwrap() > 0
+            }
+            
+            // Handler that uses the helper
+            private handle process_order(order: Map<string, any>) {
+                if (validate_order(order)) {
+                    let amount = order.get("amount").unwrap();
+                    f"Order processed. Total revenue: ${total_revenue + amount}"
+                } else {
+                    "Invalid order"
+                }
+            }
+            
+            private handle get_stats() {
+                {
+                    "order_count": orders.len(),
+                    "total_revenue": total_revenue,
+                    "average_order": if (orders.len() > 0) {
+                        total_revenue / orders.len()
+                    } else {
+                        0.0
+                    }
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse actor with private helpers: {:?}", result);
+}
+

--- a/rust/fluentai-parser/tests/test_become.rs
+++ b/rust/fluentai-parser/tests/test_become.rs
@@ -1,0 +1,133 @@
+use fluentai_parser::parse_flc;
+use fluentai_core::ast::Node;
+
+#[test]
+fn test_become_simple() {
+    let source = r#"
+        let new_state = 42;
+        become new_state
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse simple become: {:?}", result);
+    
+    let graph = result.unwrap();
+    
+    // Find the Become node
+    let has_become = graph.nodes.values().any(|node| {
+        matches!(node, Node::Become { .. })
+    });
+    
+    assert!(has_become, "Should have a Become node");
+}
+
+#[test]
+fn test_become_with_parentheses() {
+    let source = r#"
+        let counter = 0;
+        become(counter + 1)
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse become with parentheses: {:?}", result);
+}
+
+#[test]
+fn test_become_in_actor_handler() {
+    let source = r#"
+        private actor Counter {
+            count: int = 0;
+            
+            private handle increment(n: int) {
+                become count + n
+            }
+            
+            private handle reset() {
+                become 0
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse become in actor handler: {:?}", result);
+}
+
+#[test]
+fn test_become_with_complex_state() {
+    let source = r#"
+        private actor StateMachine {
+            state: string = "idle";
+            counter: int = 0;
+            
+            private handle transition(event: string) {
+                match event {
+                    "start" => become {
+                        "state": "running",
+                        "counter": counter + 1
+                    },
+                    "stop" => become {
+                        "state": "idle",
+                        "counter": 0
+                    },
+                    _ => state
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse become with complex state: {:?}", result);
+}
+
+#[test]
+fn test_become_in_receive() {
+    let source = r#"
+        private actor Worker {
+            status: string = "idle";
+            
+            private handle work() {
+                receive {
+                    "start" => {
+                        become "working";
+                        "Started working"
+                    },
+                    "pause" => {
+                        become "paused";
+                        "Work paused"
+                    },
+                    "stop" => {
+                        become "idle";
+                        "Stopped"
+                    }
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse become in receive: {:?}", result);
+}
+
+#[test]
+fn test_become_with_handler_change_future() {
+    // This test documents the desired behavior for changing handlers
+    // which might not be supported by the current AST
+    let source = r#"
+        private actor BehaviorActor {
+            mode: string = "normal";
+            
+            private handle switch_mode() {
+                if (mode == "normal") {
+                    // In the future, we might support changing the handler too
+                    become "special"
+                } else {
+                    become "normal"
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    // This should parse successfully even if full handler change isn't supported
+    assert!(result.is_ok(), "Failed to parse actor with mode switch: {:?}", result);
+}

--- a/rust/fluentai-parser/tests/test_receive_timeout.rs
+++ b/rust/fluentai-parser/tests/test_receive_timeout.rs
@@ -1,0 +1,87 @@
+use fluentai_parser::parse_flc;
+use fluentai_core::ast::Node;
+
+#[test]
+fn test_receive_with_timeout_simple() {
+    let source = r#"
+        let result = receive {
+            "ping" => "pong",
+            "status" => "ok"
+        } after(1000) {
+            "timeout"
+        };
+        result
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse receive with timeout: {:?}", result);
+    
+    let graph = result.unwrap();
+    
+    // Find the ActorReceive node and verify it has a timeout
+    let has_timeout = graph.nodes.values().any(|node| {
+        matches!(node, Node::ActorReceive { timeout: Some(_), .. })
+    });
+    
+    assert!(has_timeout, "ActorReceive node should have a timeout");
+}
+
+#[test]
+fn test_receive_with_timeout_in_actor() {
+    let source = r#"
+        private actor TimeoutActor {
+            state: string = "idle";
+            
+            private handle process(msg) {
+                receive {
+                    "work" => "working",
+                    "cancel" => "cancelled"
+                } after(5000) {
+                    "timed out"
+                }
+            }
+        }
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse actor with receive timeout: {:?}", result);
+}
+
+#[test]
+fn test_receive_timeout_with_expression() {
+    let source = r#"
+        let timeout_ms = 3000;
+        let result = receive {
+            msg => msg
+        } after(timeout_ms * 2) {
+            f"No message received in {timeout_ms * 2}ms"
+        };
+        result
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse receive with expression timeout: {:?}", result);
+}
+
+#[test]
+fn test_receive_without_timeout() {
+    let source = r#"
+        let result = receive {
+            "hello" => "world",
+            x => x
+        };
+        result
+    "#;
+    
+    let result = parse_flc(source);
+    assert!(result.is_ok(), "Failed to parse receive without timeout: {:?}", result);
+    
+    let graph = result.unwrap();
+    
+    // Find the ActorReceive node and verify it has no timeout
+    let has_no_timeout = graph.nodes.values().any(|node| {
+        matches!(node, Node::ActorReceive { timeout: None, .. })
+    });
+    
+    assert!(has_no_timeout, "ActorReceive node should not have a timeout");
+}


### PR DESCRIPTION
## Summary
- Implement multiple handler methods for actors
- Add support for typed message handlers with parameter types  
- Implement self field access in handlers (auto-transform to getters)
- Add receive with timeout syntax: `receive { ... } after(duration) { ... }`
- Implement become expression for actor state changes
- Add comprehensive parser tests for all actor features
- Update README with actor model documentation and examples

## Test plan
- [x] All existing parser tests pass
- [x] New tests added for:
  - Multiple handler methods (`test_multiple_handlers_fix.rs`)
  - Typed message handlers (`test_typed_message_handlers.rs`)
  - Self field access (`actor_field_access_tests.rs`)
  - Receive with timeout (`test_receive_timeout.rs`)
  - Become expression (`test_become.rs`)
  - Comprehensive actor features (`test_actor_comprehensive.rs`)

Closes #86

🤖 Generated with [Claude Code](https://claude.ai/code)